### PR TITLE
Fix Test 12: Encode multiline upload payload using base64

### DIFF
--- a/platformio_slip/python_client/broccoli_cluster.py
+++ b/platformio_slip/python_client/broccoli_cluster.py
@@ -11,6 +11,7 @@ Usage:
 import serial
 import time
 import re
+import base64 #added to prevent newline characters
 from typing import Any, Optional, List, Tuple, Dict
 from dataclasses import dataclass, field
 
@@ -694,10 +695,13 @@ class BroccoliCluster:
             cluster.upload_code("utils.py", "def hello(): return 'world'")
             cluster.upload_code("math_mod.py", "def add(a,b): return a+b", worker=1)
         """
+        # Base64-encode so multiline code doesn't break line-based protocol
+        code_b64 = base64.b64encode(code.encode("utf-8")).decode("ascii")
+
         if worker is None:
-            cmd = f"UPLOAD:{filename}:{code}"
+            cmd = f"UPLOAD:{filename}:B64:{code_b64}"
         else:
-            cmd = f"UPLOADW:{worker}:{filename}:{code}"
+            cmd = f"UPLOADW:{worker}:{filename}:B64:{code_b64}"
         
         self._send_command(cmd)
         response = self._read_response()


### PR DESCRIPTION
Potential fix for Test 12 issue where only the first line of a .py file was being written on the worker.

Issue:
The upload protocol is line-based (commands are terminated by '\n'), but upload_code() was sending raw multiline Python code directly in the command. This caused the payload to be split across multiple lines, so everything after the first line was ignored.

Proposed fix:
Encode the payload using base64 and prefix it with "B64:" so the entire upload command remains on a single line.

Example:
UPLOAD:filename:<multiline code>
->
UPLOAD:filename:B64:<base64 encoded payload>

Note:
This change assumes the worker recognizes the "B64:" prefix and decodes the payload before writing the file. If not already implemented, worker-side check is needed.